### PR TITLE
Refactor LowLightBoost event to state

### DIFF
--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionContext.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionContext.kt
@@ -38,7 +38,6 @@ internal data class CameraSessionContext(
     val screenFlashEvents: SendChannel<CameraSystem.ScreenFlashEvent>,
     val focusMeteringEvents: Channel<CameraEvent.FocusMeteringEvent>,
     val videoCaptureControlEvents: Channel<VideoCaptureControlEvent>,
-    val lowLightBoostEvents: MutableSharedFlow<LowLightBoostEvent>,
     val currentCameraState: MutableStateFlow<CameraState>,
     val surfaceRequests: MutableStateFlow<SurfaceRequest?>,
     val transientSettings: StateFlow<TransientSessionSettings?>

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraState.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraState.kt
@@ -28,7 +28,7 @@ data class CameraState(
     val sessionFirstFrameTimestamp: Long = 0L,
     val torchEnabled: Boolean = false,
     val stabilizationMode: StabilizationMode = StabilizationMode.OFF,
-    val lowLightBoostState: LowLightBoostState.Strength = LowLightBoostState.Strength(LowLightBoostState.MINIMUM_STRENGTH),
+    val lowLightBoostState: LowLightBoostState = LowLightBoostState.Inactive,
     val debugInfo: DebugInfo = DebugInfo(null, null),
     val videoQualityInfo: VideoQualityInfo = VideoQualityInfo(VideoQuality.UNSPECIFIED, 0, 0)
 )

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSystem.kt
@@ -108,8 +108,6 @@ interface CameraSystem {
 
     suspend fun setLowLightBoostPriority(lowLightBoostPriority: LowLightBoostPriority)
 
-    fun getLowLightBoostEvents(): SharedFlow<LowLightBoostEvent>
-
     suspend fun setLensFacing(lensFacing: LensFacing)
 
     suspend fun tapToFocus(x: Float, y: Float)

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
@@ -940,7 +940,7 @@ constructor(
     }
 
     private suspend fun handleLowLightBoostErrors() {
-        currentCameraState.map { it.lowLightBoostState }.collect { state ->
+        currentCameraState.map { it.lowLightBoostState }.distinctUntilChanged().collect { state ->
             if (state is LowLightBoostState.Error) {
                 if (currentSettings.value?.flashMode == FlashMode.LOW_LIGHT_BOOST) {
                     setFlashMode(FlashMode.OFF)

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/effects/LowLightBoostEffect.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/effects/LowLightBoostEffect.kt
@@ -41,7 +41,7 @@ class LowLightBoostEffect(
     sessionContainer: LowLightBoostSessionContainer,
     coroutineScope: CoroutineScope,
     sceneDetectorCallback: SceneDetectorCallback? = null,
-    onLowLightBoostErrorCallback: () -> Unit = {}
+    onLowLightBoostErrorCallback: (Exception) -> Unit = {}
     ) : CameraEffect(
     TARGETS,
     OUTPUT_OPTION_ONE_FOR_ALL_TARGETS,

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/effects/processors/LowLightBoostSurfaceProcessor.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/effects/processors/LowLightBoostSurfaceProcessor.kt
@@ -56,7 +56,7 @@ class LowLightBoostSurfaceProcessor(
     private val sessionContainer: LowLightBoostSessionContainer,
     private val coroutineScope: CoroutineScope,
     private val sceneDetectorCallback: SceneDetectorCallback?,
-    private val onLowLightBoostErrorCallback: () -> Unit = {}
+    private val onLowLightBoostErrorCallback: (Exception) -> Unit = {}
     ) : SurfaceProcessor {
 
     private val outputSurfaceFlow = MutableStateFlow<SurfaceOutputScope?>(null)
@@ -190,7 +190,7 @@ class LowLightBoostSurfaceProcessor(
                         Log.e(TAG, "Failed to create LowLightBoostSession or provide surface", e)
                 }
 
-                onLowLightBoostErrorCallback()
+                onLowLightBoostErrorCallback(e)
 
                 // Signal error to CameraX for the input request if it hasn't been fulfilled yet.
                 currentInputRequest.willNotProvideSurface()

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/effects/processors/LowLightBoostSurfaceProcessor.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/effects/processors/LowLightBoostSurfaceProcessor.kt
@@ -95,7 +95,7 @@ class LowLightBoostSurfaceProcessor(
             override fun onSessionDisconnected(status: Status) {
                 Log.d(TAG, "LLB session disconnected: $status")
                 releaseLowLightBoostSession()
-                onLowLightBoostErrorCallback()
+                onLowLightBoostErrorCallback(RuntimeException(status.statusMessage))
             }
         }
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraSystem.kt
@@ -170,7 +170,6 @@ class FakeCameraSystem(defaultCameraSettings: CameraAppSettings = CameraAppSetti
     override fun getSurfaceRequest(): StateFlow<SurfaceRequest?> = _surfaceRequest.asStateFlow()
 
     override fun getScreenFlashEvents() = screenFlashEvents
-    override fun getLowLightBoostEvents() = lowLightBoostEvents
     override fun getCurrentSettings(): StateFlow<CameraAppSettings?> = currentSettings.asStateFlow()
 
     override fun setFlashMode(flashMode: FlashMode) {

--- a/core/model/src/main/java/com/google/jetpackcamera/model/LowLightBoostState.kt
+++ b/core/model/src/main/java/com/google/jetpackcamera/model/LowLightBoostState.kt
@@ -16,13 +16,26 @@
 package com.google.jetpackcamera.model
 
 /**
- * Class describing the amount of Low Light Boost being applied.
+ * Interface describing the state of Low Light Boost.
  */
-sealed class LowLightBoostState {
+sealed interface LowLightBoostState {
     /**
-     * Strength of brightening being applied by Low Light Boost.
+     * Low Light Boost is not active.
      */
-    data class Strength(val value: Float) : LowLightBoostState()
+    data object Inactive : LowLightBoostState
+
+    /**
+     * Low Light Boost is active.
+     *
+     * @param strength The strength of brightening being applied.
+     */
+    data class Active(val strength: Float) : LowLightBoostState
+
+    /**
+     * An error occurred with Low Light Boost.
+     */
+    data class Error(val error: Throwable?) : LowLightBoostState
+
     companion object {
         const val MINIMUM_STRENGTH = 0.0f
         const val MAXIMUM_STRENGTH = 1.0f

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -96,7 +96,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
@@ -105,7 +104,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.supervisorScope
 
 private const val TAG = "PreviewViewModel"
 private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"

--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/TestTags.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/TestTags.kt
@@ -28,7 +28,6 @@ const val VIDEO_CAPTURE_SUCCESS_TAG = "VideoCaptureSuccessTag"
 const val VIDEO_CAPTURE_FAILURE_TAG = "VideoCaptureFailureTag"
 const val LOW_LIGHT_BOOST_FAILURE_TAG = "LowLightBoostFailureTag"
 
-
 const val IMAGE_WELL_TAG = "ImageWellTag"
 
 const val PREVIEW_DISPLAY = "PreviewDisplay"

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapter.kt
@@ -108,8 +108,12 @@ fun FlashModeUiState.updateFrom(
                 copy(selectedFlashMode = cameraAppSettings.flashMode)
             } else {
                 if (cameraAppSettings.flashMode == FlashMode.LOW_LIGHT_BOOST) {
+                    val strength = when (val llbState = cameraState.lowLightBoostState) {
+                        is LowLightBoostState.Active -> llbState.strength
+                        else -> LowLightBoostState.MINIMUM_STRENGTH
+                    }
                     copy(
-                        strength = cameraState.lowLightBoostState.value
+                        strength = strength
                     )
                 } else {
                     // Nothing has changed

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapter.kt
@@ -41,9 +41,11 @@ fun FlashModeUiState.Companion.from(
     systemConstraints: CameraSystemConstraints
 ): FlashModeUiState {
     val selectedFlashMode = cameraAppSettings.flashMode
-    val supportedFlashModes = (systemConstraints.forCurrentLens(cameraAppSettings)
-        ?.supportedFlashModes
-        ?: setOf(FlashMode.OFF)).toMutableSet()
+    val supportedFlashModes = (
+        systemConstraints.forCurrentLens(cameraAppSettings)
+            ?.supportedFlashModes
+            ?: setOf(FlashMode.OFF)
+        ).toMutableSet()
 
     if (cameraAppSettings.dynamicRange != DynamicRange.SDR) {
         supportedFlashModes.remove(FlashMode.LOW_LIGHT_BOOST)

--- a/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapterTest.kt
+++ b/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapterTest.kt
@@ -18,6 +18,7 @@ package com.google.jetpackcamera.ui.uistateadapter.capture
 import com.google.common.truth.Truth.assertThat
 import com.google.jetpackcamera.core.camera.CameraState
 import com.google.jetpackcamera.model.FlashMode
+import com.google.jetpackcamera.model.LowLightBoostState
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
 import com.google.jetpackcamera.settings.model.CameraSystemConstraints
@@ -153,5 +154,103 @@ class FlashModeUiStateAdapterTest {
                 defaultCameraState
             )
         }
+    }
+
+    @Test
+    fun updateFrom_lowLightBoostActive_updatesStrength() {
+        // Given an initial UI state with LOW_LIGHT_BOOST selected
+        val initialAppSettings = defaultCameraAppSettings.copy(flashMode = FlashMode.LOW_LIGHT_BOOST)
+        val systemConstraints = CameraSystemConstraints(
+            perLensConstraints = mapOf(
+                initialAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
+                    supportedFlashModes = setOf(FlashMode.OFF, FlashMode.LOW_LIGHT_BOOST)
+                )
+            )
+        )
+        val uiState = FlashModeUiState.from(initialAppSettings, systemConstraints)
+        assertThat(uiState).isInstanceOf(FlashModeUiState.Available::class.java)
+
+        // When the camera state reports active low light boost
+        val cameraState = defaultCameraState.copy(
+            lowLightBoostState = LowLightBoostState.Active(strength = 0.7f)
+        )
+        val updatedUiState = uiState.updateFrom(
+            initialAppSettings,
+            systemConstraints,
+            cameraState
+        )
+
+        // Then the strength is updated in the UI state
+        assertThat(updatedUiState).isInstanceOf(FlashModeUiState.Available::class.java)
+        val availableUiState = updatedUiState as FlashModeUiState.Available
+        assertThat(availableUiState.strength).isEqualTo(0.7f)
+    }
+
+    @Test
+    fun updateFrom_lowLightBoostInactive_resetsStrength() {
+        // Given an initial UI state with active low light boost strength
+        val initialAppSettings = defaultCameraAppSettings.copy(flashMode = FlashMode.LOW_LIGHT_BOOST)
+        val systemConstraints = CameraSystemConstraints(
+            perLensConstraints = mapOf(
+                initialAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
+                    supportedFlashModes = setOf(FlashMode.OFF, FlashMode.LOW_LIGHT_BOOST)
+                )
+            )
+        )
+        val initialCameraState = defaultCameraState.copy(
+            lowLightBoostState = LowLightBoostState.Active(strength = 0.7f)
+        )
+        var uiState = FlashModeUiState.from(initialAppSettings, systemConstraints)
+        uiState = uiState.updateFrom(initialAppSettings, systemConstraints, initialCameraState)
+        assertThat((uiState as FlashModeUiState.Available).strength).isEqualTo(0.7f)
+
+        // When the camera state reports inactive low light boost
+        val newCameraState = defaultCameraState.copy(
+            lowLightBoostState = LowLightBoostState.Inactive
+        )
+        val updatedUiState = uiState.updateFrom(
+            initialAppSettings,
+            systemConstraints,
+            newCameraState
+        )
+
+        // Then the strength is reset to 0
+        assertThat(updatedUiState).isInstanceOf(FlashModeUiState.Available::class.java)
+        val availableUiState = updatedUiState as FlashModeUiState.Available
+        assertThat(availableUiState.strength).isEqualTo(0.0f)
+    }
+
+    @Test
+    fun updateFrom_lowLightBoostError_resetsStrength() {
+        // Given an initial UI state with active low light boost strength
+        val initialAppSettings = defaultCameraAppSettings.copy(flashMode = FlashMode.LOW_LIGHT_BOOST)
+        val systemConstraints = CameraSystemConstraints(
+            perLensConstraints = mapOf(
+                initialAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
+                    supportedFlashModes = setOf(FlashMode.OFF, FlashMode.LOW_LIGHT_BOOST)
+                )
+            )
+        )
+        val initialCameraState = defaultCameraState.copy(
+            lowLightBoostState = LowLightBoostState.Active(strength = 0.7f)
+        )
+        var uiState = FlashModeUiState.from(initialAppSettings, systemConstraints)
+        uiState = uiState.updateFrom(initialAppSettings, systemConstraints, initialCameraState)
+        assertThat((uiState as FlashModeUiState.Available).strength).isEqualTo(0.7f)
+
+        // When the camera state reports a low light boost error
+        val newCameraState = defaultCameraState.copy(
+            lowLightBoostState = LowLightBoostState.Error(Throwable())
+        )
+        val updatedUiState = uiState.updateFrom(
+            initialAppSettings,
+            systemConstraints,
+            newCameraState
+        )
+
+        // Then the strength is reset to 0
+        assertThat(updatedUiState).isInstanceOf(FlashModeUiState.Available::class.java)
+        val availableUiState = updatedUiState as FlashModeUiState.Available
+        assertThat(availableUiState.strength).isEqualTo(0.0f)
     }
 }

--- a/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapterTest.kt
+++ b/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapterTest.kt
@@ -159,7 +159,9 @@ class FlashModeUiStateAdapterTest {
     @Test
     fun updateFrom_lowLightBoostActive_updatesStrength() {
         // Given an initial UI state with LOW_LIGHT_BOOST selected
-        val initialAppSettings = defaultCameraAppSettings.copy(flashMode = FlashMode.LOW_LIGHT_BOOST)
+        val initialAppSettings = defaultCameraAppSettings.copy(
+            flashMode = FlashMode.LOW_LIGHT_BOOST
+        )
         val systemConstraints = CameraSystemConstraints(
             perLensConstraints = mapOf(
                 initialAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
@@ -189,7 +191,9 @@ class FlashModeUiStateAdapterTest {
     @Test
     fun updateFrom_lowLightBoostInactive_resetsStrength() {
         // Given an initial UI state with active low light boost strength
-        val initialAppSettings = defaultCameraAppSettings.copy(flashMode = FlashMode.LOW_LIGHT_BOOST)
+        val initialAppSettings = defaultCameraAppSettings.copy(
+            flashMode = FlashMode.LOW_LIGHT_BOOST
+        )
         val systemConstraints = CameraSystemConstraints(
             perLensConstraints = mapOf(
                 initialAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
@@ -223,7 +227,9 @@ class FlashModeUiStateAdapterTest {
     @Test
     fun updateFrom_lowLightBoostError_resetsStrength() {
         // Given an initial UI state with active low light boost strength
-        val initialAppSettings = defaultCameraAppSettings.copy(flashMode = FlashMode.LOW_LIGHT_BOOST)
+        val initialAppSettings = defaultCameraAppSettings.copy(
+            flashMode = FlashMode.LOW_LIGHT_BOOST
+        )
         val systemConstraints = CameraSystemConstraints(
             perLensConstraints = mapOf(
                 initialAppSettings.cameraLensFacing to emptyCameraConstraints.copy(


### PR DESCRIPTION
This removes LLB "events" which can be more simply represented as a state within the existing LowLightBoostState.

This change merges the failure event into LowLightBoostState as a new 'Error' state. This allows for the removal of the lowLightBoostEvents channel from the CameraSystem interface, simplifying the public API and ensuring unidirectional data flow.

The PreviewViewModel and associated UI have been updated to handle the new `Error` state correctly.

This also renames the "Strength" LowLightBoostState to "Active" and adds an "Inactive" state to the sealed interface.